### PR TITLE
Declare glfwGetOpenedFilename() for export

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5628,6 +5628,7 @@ GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window
 
 /* -------------------- END SYSTEM/COMPILER SPECIFIC --------------------- */
 
+const char *glfwGetOpenedFilename();
 
 #ifdef __cplusplus
 }

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5628,7 +5628,7 @@ GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window
 
 /* -------------------- END SYSTEM/COMPILER SPECIFIC --------------------- */
 
-const char *glfwGetOpenedFilename();
+GLFWAPI const char *glfwGetOpenedFilename();
 
 #ifdef __cplusplus
 }

--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -459,6 +459,13 @@ static GLFWbool initializeTIS(void)
         _glfwRestoreVideoModeNS(_glfw.monitors[i]);
 }
 
+- (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename
+{
+    const char *filenameStr = [filename UTF8String];
+    snprintf(glfwOpenedFilename, sizeof(glfwOpenedFilename), "%s", filenameStr);
+    return YES;
+}
+
 @end // GLFWApplicationDelegate
 
 

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -410,6 +410,11 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     return YES;
 }
 
+- (BOOL)acceptsFirstMouse:(NSEvent *)event
+{
+    return YES;
+}
+
 - (void)mouseDown:(NSEvent *)event
 {
     _glfwInputMouseClick(window,

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -410,11 +410,6 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     return YES;
 }
 
-- (BOOL)acceptsFirstMouse:(NSEvent *)event
-{
-    return YES;
-}
-
 - (void)mouseDown:(NSEvent *)event
 {
     _glfwInputMouseClick(window,

--- a/src/init.c
+++ b/src/init.c
@@ -336,3 +336,14 @@ GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun cbfun)
     return cbfun;
 }
 
+
+char glfwOpenedFilename[1024];
+
+const char *glfwGetOpenedFilename()
+{
+    if (glfwOpenedFilename[0])
+    {
+        return glfwOpenedFilename;
+    }
+    return NULL;
+}

--- a/src/init.c
+++ b/src/init.c
@@ -339,7 +339,7 @@ GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun cbfun)
 
 char glfwOpenedFilename[1024];
 
-const char *glfwGetOpenedFilename()
+GLFWAPI const char *glfwGetOpenedFilename()
 {
     if (glfwOpenedFilename[0])
     {

--- a/src/internal.h
+++ b/src/internal.h
@@ -774,3 +774,5 @@ char* _glfw_strdup(const char* source);
 float _glfw_fminf(float a, float b);
 float _glfw_fmaxf(float a, float b);
 
+
+extern char glfwOpenedFilename[1024];


### PR DESCRIPTION
Currently Rack only builds when glfw is linked in statically. For NixOS (and likely other distributions) it would be desirable to link it dynamically though.

This patch exports `glfwGetOpenedFilename()` so that it is included when glfw is build dynamically.